### PR TITLE
chore: update minimum Node.js version to 16.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
       - node/test:
           post-node-js-install-steps:
             - run: test/ci/before_install.sh
-          override-ci-command: yarn install --frozen-lockfile --ignore-engines
           test-steps:
             - run: yarn build
             - restore_cache:
@@ -63,7 +62,7 @@ workflows:
               node-version:
                 - 20.2.0
                 - 18.14.0
-                - 16.4.0
+                - 16.13.0
           filters:
             branches: { ignore: gh-pages }
       - cfa/release:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It generates executables/bundles for the following **target** platforms:
 
 ## Installation
 
-This module requires Node.js 16.4.0 or higher to run.
+This module requires Node.js 16.13.0 or higher to run.
 
 ```sh
 npm install --save-dev @electron/packager

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "^5.2.2"
   },
   "engines": {
-    "node": ">= 16.4.0"
+    "node": ">= 16.13.0"
   },
   "scripts": {
     "ava": "ava test/index.js",


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

`--ignore-engines` is no longer needed after #1608, and removing it revealed that we actually need `>= 16.13`. I think it changed as a result of #1593. It's probably only a dev dependency forcing it, but we can't differentiate between the minimum engine version for dev versus prod so we usually peg them to whichever is higher. In this case it doesn't really make a practical difference, users should probably be using the latest minor release anyway.