### PR TITLE
fix: update broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ via [Homebrew](https://brew.sh/).
 
 ### Via JavaScript
 
-JavaScript API usage can be found in the [API documentation](https://electron.github.io/packager/main/modules/electronpackager.html).
+JavaScript API usage can be found in the [API documentation](https://electron.github.io/packager/main/).
 
 ### From the command line
 
@@ -101,7 +101,7 @@ This will:
 
 For an overview of the other optional flags, run `electron-packager --help` or see
 [usage.txt](https://github.com/electron/packager/blob/main/usage.txt). For
-detailed descriptions, see the [API documentation](https://electron.github.io/packager/main/modules/electronpackager.html).
+detailed descriptions, see the [API documentation](https://electron.github.io/packager/main/).
 
 For flags that are structured as objects, you can pass each option as via dot notation as such:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,7 +14,7 @@ and packaged modes, you'll need to [define it yourself](https://electronjs.org/d
 
 ## Why isn't my `ignore` option working?
 
-As stated in the documentation for [`ignore`](https://electron.github.io/packager/main/interfaces/electronpackager.options.html#ignore), it uses "[one] or more additional
+As stated in the documentation for [`ignore`](https://electron.github.io/packager/main/interfaces/Options.html#ignore), it uses "[one] or more additional
 [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
 patterns. […] Please note that [glob patterns](https://en.wikipedia.org/wiki/Glob_%28programming%29)
 will not work."
@@ -44,7 +44,7 @@ console.log(require(jsonFilename));
 
 ## How do I set an icon on Linux?
 
-The docs for [`icon`](https://electron.github.io/packager/main/interfaces/electronpackager.options.html#icon)
+The docs for [`icon`](https://electron.github.io/packager/main/interfaces/Options.html#icon)
 already show how to set an icon on your `BrowserWindow`, but your dock/taskbar may not use that and
 instead use the `Icon` value in your `.desktop` file. The [Linux distributable creators](https://github.com/electron/packager#distributable-creators)
 can help you set/distribute the appropriate icon in that case.

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -32,7 +32,7 @@ function errorMessageForProperty(prop: string) {
 
   return `Unable to determine ${propDescription}. Please specify an ${propDescription}\n\n` +
     'For more information, please see\n' +
-    `https://electron.github.io/packager/main/interfaces/electronpackager.options.html#${hash}\n`;
+    `https://electron.github.io/packager/main/interfaces/Options.html#${hash}\n`;
 }
 
 function resolvePromise(id: string, options: AsyncOpts) {

--- a/usage.txt
+++ b/usage.txt
@@ -55,7 +55,7 @@ extra-resource     a file to copy into the app's resources directory
 icon               the local path to an icon file to use as the icon for the app.
                    Note: Format depends on platform.
 ignore             do not copy files into app whose filenames RegExp.match this string. See also:
-                   https://electron.github.io/packager/main/interfaces/electronpackager.options.html#ignore
+                   https://electron.github.io/packager/main/interfaces/Options.html#ignore
                    and --no-prune. Can be specified multiple times
 no-deref-symlinks  make sure symlinks are not dereferenced within the app source
 no-junk            do not ignore system junk files from the packaged app
@@ -102,7 +102,7 @@ osx-universal      (macOS host platform only, requires --arch=universal) Options
                    when packaging a Universal macOS binary. You must use dot notation to configure a list of sub-properties,
                    e.g. --osx-universal.mergeASARs="true"
                    For info on supported values see
-                   https://electron.github.io/packager/main/modules/electronpackager.html#osxuniversaloptions
+                   https://electron.github.io/packager/main/types/OsxUniversalOptions.html
 windows-sign       Whether to sign Windows binary files with a codesigning certificate. You can either
                    pass --windows-sign by itself to use the default configuration or use dot notation to configure
                    a list of sub-properties, e.g. --windows-sign.certificateFile="C:\cert.pfx".


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Updates broken documentation links from the TypeDoc upgrade (#1614).

Fixes #1631.

