### PR TITLE
build: add shim to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ typedoc
 .nyc_output
 npm-debug.log
 dist/
+src/targets.js


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

The shim introduced in #1641 causes [an issue with the docs publish workflow](https://github.com/electron/packager/actions/runs/7263804212/job/19789924601) since it is seen as an uncommitted file. Adding it to `.gitignore` fixes that.