### PR TITLE
chore: remove broken default option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,6 @@ export function parseArgs(argv: string[]) {
     boolean: [
       'all',
       'deref-symlinks',
-      'download.rejectUnauthorized',
       'junk',
       'overwrite',
       'prune',
@@ -27,7 +26,6 @@ export function parseArgs(argv: string[]) {
     ],
     default: {
       'deref-symlinks': true,
-      'download.rejectUnauthorized': true,
       junk: true,
       prune: true
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -340,8 +340,6 @@ export interface Options {
    * include, but are not limited to:
    * - `cacheRoot` (*string*): The directory where prebuilt, pre-packaged Electron downloads are cached.
    * - `mirrorOptions` (*Object*): Options to override the default Electron download location.
-   * - `rejectUnauthorized` (*boolean* - default: `true`): Whether SSL certificates are required to be
-   *   valid when downloading Electron.
    *
    * **Note:** `download` sub-options will have no effect if the {@link electronZipDir} option is set.
    */

--- a/test/cli.js
+++ b/test/cli.js
@@ -11,16 +11,6 @@ test('CLI argument: --electron-version populates opts.electronVersion', t => {
   t.is(args.electronVersion, '1.2.3')
 })
 
-test('CLI argument: --download.rejectUnauthorized default', t => {
-  const args = parseArgs([])
-  t.true(args.download.rejectUnauthorized, 'default for --download.rejectUnauthorized is true')
-})
-
-test('CLI argument: --no-download.rejectUnauthorized makes rejectUnauthorized false', t => {
-  const args = parseArgs(['--no-download.rejectUnauthorized'])
-  t.false(args.download.rejectUnauthorized, 'download.rejectUnauthorized should be false')
-})
-
 test('CLI argument: --asar=true', t => {
   const args = parseArgs(['--asar=true'])
   t.true(args.asar)

--- a/usage.txt
+++ b/usage.txt
@@ -44,9 +44,6 @@ download           a list of sub-options to pass to @electron/get. They are spec
                      @electron/get documentation
                    - mirrorOptions: alternate URL options for downloading Electron zips. See
                      @electron/get documentation for details
-                   - rejectUnauthorized: whether SSL certs are required to be valid when downloading
-                     Electron. Defaults to true, use --no-download.rejectUnauthorized to disable
-                     checks.
 electron-version   the version of Electron that is being packaged, see
                    https://github.com/electron/electron/releases
 electron-zip-dir   the local path to a directory containing Electron ZIP files


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This default value has been broken for a while, as `@electron/get` expects the `rejectUnauthorized` property inside the `downloadOptions` object, not as a top-level option. This PR is just updating the docs to reflect the current behavior.