### PR TITLE
fix: appDireactory missing for windows-sign options

### DIFF
--- a/src/win32.ts
+++ b/src/win32.ts
@@ -74,6 +74,7 @@ export class WindowsApp extends App {
 
     if (windowsSignOpt) {
       const signOpts = createSignOpts(windowsSignOpt, windowsMetaData);
+      signOpts.appDirectory = this.stagingPath;
       debug(`Running @electron/windows-sign with the options ${JSON.stringify(signOpts)}`);
       try {
         await sign(signOpts as WindowsInternalSignOptions);

--- a/src/win32.ts
+++ b/src/win32.ts
@@ -73,8 +73,7 @@ export class WindowsApp extends App {
     const windowsMetaData = this.opts.win32metadata;
 
     if (windowsSignOpt) {
-      const signOpts = createSignOpts(windowsSignOpt, windowsMetaData);
-      signOpts.appDirectory = this.stagingPath;
+      const signOpts = createSignOpts(windowsSignOpt, windowsMetaData, this.stagingPath);
       debug(`Running @electron/windows-sign with the options ${JSON.stringify(signOpts)}`);
       try {
         await sign(signOpts as WindowsInternalSignOptions);
@@ -99,8 +98,11 @@ export class WindowsApp extends App {
   }
 }
 
-function createSignOpts(properties: ComboOptions['windowsSign'],
-  windowsMetaData: ComboOptions['win32metadata']): WindowsSignOptions {
+function createSignOpts(
+  properties: ComboOptions['windowsSign'],
+  windowsMetaData: ComboOptions['win32metadata'],
+  appDirectory: string,
+): WindowsSignOptions & WindowsInternalSignOptions {
   let result: WindowsSignOptions = {};
 
   if (typeof properties === 'object') {
@@ -112,7 +114,7 @@ function createSignOpts(properties: ComboOptions['windowsSign'],
     result.description = windowsMetaData.FileDescription;
   }
 
-  return result;
+  return { ...result, appDirectory };
 }
 
 export { WindowsApp as App };


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Fixing windows-sign does not work due to `appDirectory` missing.
