### PR TITLE
chore: replace legacy `var` with `const`

### DIFF
--- a/bin/electron-packager.js
+++ b/bin/electron-packager.js
@@ -2,15 +2,13 @@
 
 'use strict'
 
-/* eslint-disable no-var */
-// WHY: not consts so that this file can load in Node < 4.0
-var packageJSON = require('../package.json')
-var semver = require('semver')
+const packageJSON = require('../package.json')
+const semver = require('semver')
 if (!semver.satisfies(process.versions.node, packageJSON.engines.node)) {
   console.error('CANNOT RUN WITH NODE ' + process.versions.node)
   console.error('Electron Packager requires Node ' + packageJSON.engines.node + '.')
   process.exit(1)
 }
 
-var cli = require('../dist/cli')
+const cli = require('../dist/cli')
 cli.run(process.argv.slice(2))


### PR DESCRIPTION
Now that `engines` requires Node.js 16