### PR TITLE
chore: reduce number of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 99
-  ignore:
-  - dependency-name: typedoc
-    versions:
-    - ">= 0.20.a, < 0.21"
-  - dependency-name: sinon
-    versions:
-    - 10.0.0
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    # Check for updates to GitHub Actions every weekday
-    interval: "daily"
+    interval: "monthly"


### PR DESCRIPTION
Dependabot currently attempts to upgrade all dependencies, even if not necessary for security reasons.

I modified our `dependabot.yml` to align with [Forge's](https://github.com/electron/forge/blob/main/.github/dependabot.yml).