### PR TITLE
fix: include asar integrity when using --prebuilt-asar

### DIFF
--- a/test/darwin.js
+++ b/test/darwin.js
@@ -498,4 +498,22 @@ if (!(process.env.CI && process.platform === 'win32')) {
       }
     })
   }))
+
+  test.serial('prebuilt asar integrity hashes are automatically inserted', darwinTest(async (t, baseOpts) => {
+    const opts = {
+      ...baseOpts,
+      dir: util.fixtureSubdir('asar-prebuilt')
+    }
+    opts.prebuiltAsar = path.join(opts.dir, 'app.asar')
+    const finalPath = (await packager(opts))[0]
+    const plistObj = await parseInfoPlist(t, opts, finalPath)
+    t.is(typeof plistObj.ElectronAsarIntegrity, 'object')
+    // Note: If you update test/fixtures/asar-prebuilt/app.asar, ths hash should also be updated.
+    t.deepEqual(plistObj.ElectronAsarIntegrity, {
+      'Resources/app.asar': {
+        algorithm: 'SHA256',
+        hash: '5efe069acf1f8d2622f2da149fcedcd5e17f9e7f4bc6f7ffe89255ee96647d4f'
+      }
+    })
+  }))
 }


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

If you are building an app with a prebuilt ASAR archive, we should still include the ASAR integrity hash in the app bundle.