### PR TITLE
fix: use target platform path separators for asar integrity keys

### DIFF
--- a/src/mac.ts
+++ b/src/mac.ts
@@ -233,8 +233,8 @@ export class MacApp extends App implements Plists {
     return [...plists, ...(optional as LoadPlistParams[]).filter(item => item)];
   }
 
-  appRelativePath(p: string) {
-    return path.relative(this.contentsPath, p);
+  appRelativePlatformPath(p: string) {
+    return path.posix.relative(this.contentsPath, p);
   }
 
   async updatePlistFiles() {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -138,7 +138,7 @@ export class App {
     if (this.opts.prebuiltAsar) {
       await this.copyPrebuiltAsar();
       this.asarIntegrity = {
-        [this.appRelativePath(this.appAsarPath)]: this.getAsarIntegrity(this.appAsarPath),
+        [this.appRelativePlatformPath(this.appAsarPath)]: this.getAsarIntegrity(this.appAsarPath),
       };
     } else {
       await this.buildApp();
@@ -232,8 +232,12 @@ export class App {
     await fs.copy(src, this.appAsarPath, { overwrite: false, errorOnExist: true });
   }
 
-  appRelativePath(p: string) {
-    return path.relative(this.stagingPath, p);
+  appRelativePlatformPath(p: string) {
+    if (this.opts.platform === 'win32') {
+      return path.win32.relative(this.stagingPath, p);
+    }
+
+    return path.posix.relative(this.stagingPath, p);
   }
 
   async asarApp() {
@@ -247,7 +251,7 @@ export class App {
 
     await asar.createPackageWithOptions(this.originalResourcesAppDir, this.appAsarPath, this.asarOptions);
     this.asarIntegrity = {
-      [this.appRelativePath(this.appAsarPath)]: this.getAsarIntegrity(this.appAsarPath),
+      [this.appRelativePlatformPath(this.appAsarPath)]: this.getAsarIntegrity(this.appAsarPath),
     };
     await fs.remove(this.originalResourcesAppDir);
 


### PR DESCRIPTION
After the `resedit` change cross-building windows on macOS is suddenly a Thing People Can Do so we need to make sure we use windows path separators for the asar integrity manifest when targeting the windows platform.

Fixes #1780