### PR TITLE
ci: test node 22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ workflows:
                 - node/macos
                 - node/windows
               node-version:
+                - 22.9.0
                 - 20.2.0
                 - 18.14.0
                 - 16.13.0


### PR DESCRIPTION
Adds CI for the latest LTS version of Node.js
