### PR TITLE
docs: remove references to CircleCI and AppVeyor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ We use the label [`help wanted`](https://github.com/electron/packager/issues?q=i
 
 Here are some things to keep in mind as you file pull requests to fix bugs, add new features, etc.:
 
-* CircleCI and AppVeyor are used to make sure that the project builds packages as expected on the
+* GitHub Actions is used to make sure that the project builds packages as expected on the
   supported platforms, using supported Node.js versions.
 * Unless it's impractical, please write tests for your changes. This will help us so that we can
   spot regressions much easier.


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Follow-up to #1784 to remove references in `CONTRIBUTING.md` to the old CI systems.