### PR TITLE
feat!: hooks are promisified

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,7 +1,7 @@
 import { FinalizePackageTargetsHookFunction, HookFunction } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Fn = (...args: any[]) => Promise<void>;
+type Fn = (...args: any[]) => Promise<void> | void;
 
 export async function runHooks<T extends Fn>(hooks: T[] | undefined, args?: Parameters<T>) {
   if (hooks === undefined || !Array.isArray(hooks)) {
@@ -22,15 +22,14 @@ export async function runHooks<T extends Fn>(hooks: T[] | undefined, args?: Para
  * packager({
  *   // ...
  *   afterCopy: [serialHooks([
- *     (buildPath, electronVersion, platform, arch, callback) => {
- *       setTimeout(() => {
- *         console.log('first function')
- *         callback()
- *       }, 1000)
+ *     async (buildPath, electronVersion, platform, arch) => {
+ *       await new Promise(resolve => setTimeout(() => {
+ *         console.log('first function');
+ *         resolve()
+ *       }, 1000))
  *     },
- *     (buildPath, electronVersion, platform, arch, callback) => {
+ *     (buildPath, electronVersion, platform, arch) => {
  *       console.log('second function')
- *       callback()
  *     }
  *   ])],
  *   // ...

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,13 +107,13 @@ export type HookFunction =
     electronVersion: string,
     platform: TargetPlatform,
     arch: TargetArch,
-  ) => Promise<void>;
+  ) => Promise<void> | void;
 
 export type TargetDefinition = {
   arch: TargetArch;
   platform: TargetPlatform;
 }
-export type FinalizePackageTargetsHookFunction = (targets: TargetDefinition[]) => Promise<void>;
+export type FinalizePackageTargetsHookFunction = (targets: TargetDefinition[]) => Promise<void> | void;
 
 /** See the documentation for [`@electron/osx-sign`](https://npm.im/@electron/osx-sign#opts) for details.
  * @interface

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,8 +56,6 @@ export type SupportedPlatform = OfficialPlatform | 'all';
 
 export type IgnoreFunction = (path: string) => boolean;
 
-export type HookFunctionErrorCallback = (err?: Error | null) => void
-
 /**
  * A function that is called on the completion of a packaging stage.
  *
@@ -109,14 +107,13 @@ export type HookFunction =
     electronVersion: string,
     platform: TargetPlatform,
     arch: TargetArch,
-    callback: HookFunctionErrorCallback,
-  ) => void;
+  ) => Promise<void>;
 
 export type TargetDefinition = {
   arch: TargetArch;
   platform: TargetPlatform;
 }
-export type FinalizePackageTargetsHookFunction = (targets: TargetDefinition[], callback: HookFunctionErrorCallback) => void;
+export type FinalizePackageTargetsHookFunction = (targets: TargetDefinition[]) => Promise<void>;
 
 /** See the documentation for [`@electron/osx-sign`](https://npm.im/@electron/osx-sign#opts) for details.
  * @interface

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -243,11 +243,10 @@ if (!(process.env.CI && process.platform === 'win32')) {
     let expectedChecksum
     opts.icon = path.join(__dirname, 'fixtures', 'nonexistent')
     opts.afterExtract = [
-      async (extractPath, _electronVersion, _platform, _arch, callback) => {
+      async (extractPath) => {
         const hash = crypto.createHash('sha256')
         hash.update(await fs.readFile(path.join(extractPath, 'Electron.app', 'Contents', 'Resources', 'electron.icns')))
         expectedChecksum = hash.digest('hex')
-        callback()
       }
     ]
 
@@ -443,10 +442,9 @@ if (!(process.env.CI && process.platform === 'win32')) {
     ]
     const opts = {
       ...baseOpts,
-      afterExtract: [(buildPath, electronVersion, platform, arch, cb) => {
+      afterExtract: [(buildPath) => {
         return Promise.all(helpers.map(async helper => {
           await fs.remove(getHelperAppPath(buildPath, 'Electron', helper))
-          cb()
         }))
       }]
     }


### PR DESCRIPTION
BREAKING CHANGE: hooks now take in promises instead of callbacks

This PR addresses the underlying issue in https://github.com/electron/forge/issues/3828 and modernizes our hook code to use Promises rather than callback-style asynchronous code.

**The changes are ready for review, but we need to tie this PR (and any other breaking changes we might want to make) to the Node 22 upgrade.**