### PR TITLE
build: move husky from postinstall to prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "test": "npm run lint && npm run coverage",
-    "postinstall": "husky install"
+    "prepare": "husky install"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Follow-up to #1792 that moves `husky install` from the `postinstall` script (wrong spot) to `prepare`.