### PR TITLE
ci: update docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,45 +2,34 @@ name: Publish documentation
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
 
-permissions: {}
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   docs:
     runs-on: ubuntu-latest
+    environment: docs-publish
     steps:
-      - name: Generate GitHub App token
-        uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
-        id: generate-token
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          creds: ${{ secrets.GH_APP_CREDS }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # tag: v4.2.2
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Build API documentation
+        run: yarn build:docs
+      - name: Azure login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
-          token: ${{ steps.generate-token.outputs.token }}
-      - name: Fetch all git branches
-        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # tag: v4.4.0
+          client-id: ${{ secrets.AZURE_OIDC_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_OIDC_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_OIDC_SUBSCRIPTION_ID }}
+      - name: Upload to Azure Blob Storage
+        uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
         with:
-          node-version: lts/*
-      - run: yarn install --frozen-lockfile
-      - run: yarn run docs:build
-      - name: Prepare docs
-        uses: malept/github-action-gh-pages@f7952a65c4b763dc84b824a530dc38bd375ac91e  # tag: v1.4.0
-        with:
-          defaultBranch: main
-          docsPath: typedoc
-          noCommit: true
-          showUnderscoreFiles: true
-          versionDocs: true
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-      - name: Commit docs
-        uses: dsanders11/github-app-commit-action@43de6da2f4d927e997c0784c7a0b61bd19ad6aac # v1.5.0
-        with:
-          fail-on-no-changes: false
-          message: 'Publish [skip ci]'
-          token: ${{ steps.generate-token.outputs.token }}
+          inlineScript: |
+            az storage blob upload-batch --account-name ${{ secrets.AZURE_ECOSYSTEM_PACKAGES_STORAGE_ACCOUNT_NAME }} -d '$web/${{ github.event.repository.name }}/${{ github.ref_name }}' -s ./docs --overwrite --auth-mode login

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,4 +59,4 @@ jobs:
           files: ./coverage.lcov
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Build Docs
-        run: yarn run docs:build
+        run: yarn run build:docs

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "postbuild": "copyfiles -f ./temp/targets.js ./src",
     "coverage": "nyc ava test/index.js",
     "coverage:report": "nyc report --reporter=text-lcov > coverage.lcov",
-    "docs:build": "npx typedoc",
+    "build:docs": "npx typedoc",
     "lint": "prettier --check \"*.{ts,js,json}\" && eslint . --cache",
     "prepublish": "npm run build",
     "pretest": "npm run build",


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

The existing docs workflow no longer works, so replace it with the generic workflow we've been using for repos when we do the Node.js 22 upgrade. That way if we put out another release before we get around to the Node.js 22 upgrade, the docs will publish properly.