### PR TITLE
build(deps): add `@types/node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.10",
     "@types/fs-extra": "^11.0.3",
+    "@types/node": "^16.0.0",
     "@types/parse-author": "^2.0.2",
     "@types/plist": "^3.0.4",
     "@types/resolve": "^1.20.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,6 +634,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
+"@types/node@^16.0.0":
+  version "16.18.126"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.126.tgz#27875faa2926c0f475b39a8bb1e546c0176f8d4b"
+  integrity sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"


### PR DESCRIPTION
The `@types/node` package was missing from our devDependencies, leading to some head-scratching TypeScript compilation errors.