### PR TITLE
fix: fix semver check for icon composer

### DIFF
--- a/src/icon-composer.ts
+++ b/src/icon-composer.ts
@@ -7,7 +7,7 @@ import plist from 'plist';
 import semver from 'semver';
 
 export async function generateAssetCatalogForIcon(inputPath: string) {
-  if (!semver.gte(os.version(), '25.0.0')) {
+  if (!semver.gte(os.release(), '25.0.0')) {
     throw new Error(
       `actool .icon support is currently limited to macOS 26 and higher`
     );


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

Follow up to #1806, this PR corrects how the os versioning is checked when trying to use the new Icon Composer icon feature.

