### PR TITLE
ci: upload `/typedoc` folder to packages.electronjs.org

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,4 +32,4 @@ jobs:
         uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
         with:
           inlineScript: |
-            az storage blob upload-batch --account-name ${{ secrets.AZURE_ECOSYSTEM_PACKAGES_STORAGE_ACCOUNT_NAME }} -d '$web/${{ github.event.repository.name }}/${{ github.ref_name }}' -s ./docs --overwrite --auth-mode login
+            az storage blob upload-batch --account-name ${{ secrets.AZURE_ECOSYSTEM_PACKAGES_STORAGE_ACCOUNT_NAME }} -d '$web/${{ github.event.repository.name }}/${{ github.ref_name }}' -s ./typedoc --overwrite --auth-mode login


### PR DESCRIPTION
We use a different folder for the API documentation flow so the last couple uploads have only uploaded the actual `/docs` folder. I think this fixes it: https://github.com/electron/packager/pull/1807