### PR TITLE
build: ignore fixture package.json in socket

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,4 @@
+version: 2
+
+projectIgnorePaths:
+- "test/fixtures/basic"


### PR DESCRIPTION
This fixture file is never "npm install"'ed and as such the missing lockfile should not be penalized in socket