### PR TITLE
feat!: default `derefSymlinks` to `true`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,6 @@ export function parseArgs(argv: string[]) {
   const args = yargs(argv, {
     boolean: ['all', 'deref-symlinks', 'junk', 'overwrite', 'prune', 'quiet'],
     default: {
-      'deref-symlinks': true,
       junk: true,
       prune: true,
     },

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -193,7 +193,10 @@ export class App {
     await fs.promises.cp(this.opts.dir, this.originalResourcesAppDir, {
       recursive: true,
       filter: userPathFilter(this.opts),
-      dereference: Boolean(this.opts.derefSymlinks),
+      dereference:
+        typeof this.opts.derefSymlinks === 'boolean'
+          ? this.opts.derefSymlinks
+          : true,
     });
     await promisifyHooks(
       this.opts.afterCopy,

--- a/src/types.ts
+++ b/src/types.ts
@@ -357,7 +357,7 @@ export interface Options {
    *
    * **Note:** `derefSymlinks` will have no effect if the {@link prebuiltAsar} option is set.
    *
-   * @defaultValue false
+   * @defaultValue true
    *
    */
   derefSymlinks?: boolean;

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -58,11 +58,6 @@ describe('parseArgs', () => {
     expect(args.tmpdir).toBe(false);
   });
 
-  it('defaults to derefSymlinks', () => {
-    const args = parseArgs([]);
-    expect(args.derefSymlinks).toBe(true);
-  });
-
   it('always resolves --out to be a string', () => {
     const args = parseArgs(['--out=1']);
     expect(args.out).toBe('1');


### PR DESCRIPTION
BREAKING CHANGE: defaults to `derefSymlinks: true` if the value isn't explicitly defined.

This PR also removes the second layer of logic that defaults this value via the CLI (instead specifying it in the core API).