### PR TITLE
refactor: improve `Options` types

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -3,7 +3,7 @@ import fs from 'graceful-fs';
 import os from 'node:os';
 import path from 'node:path';
 import createDebug from 'debug';
-import { ComboOptions, Options } from './types.js';
+import { ProcessedOptionsWithSinglePlatformArch, Options } from './types.js';
 import { CreateOptions as AsarOptions } from '@electron/asar';
 
 export const debug = createDebug('electron-packager');
@@ -13,12 +13,17 @@ export function sanitizeAppName(name: string) {
 }
 
 export function generateFinalBasename(
-  opts: Pick<ComboOptions, 'arch' | 'name' | 'platform'>,
+  opts: Pick<
+    ProcessedOptionsWithSinglePlatformArch,
+    'arch' | 'name' | 'platform'
+  >,
 ) {
-  return `${sanitizeAppName(opts.name!)}-${opts.platform}-${opts.arch}`;
+  return `${sanitizeAppName(opts.name)}-${opts.platform}-${opts.arch}`;
 }
 
-export function generateFinalPath(opts: ComboOptions) {
+export function generateFinalPath(
+  opts: ProcessedOptionsWithSinglePlatformArch,
+) {
   return path.join(opts.out || process.cwd(), generateFinalBasename(opts));
 }
 
@@ -50,7 +55,9 @@ export function subOptionWarning(
   properties[parameter] = value;
 }
 
-export function createAsarOpts(opts: ComboOptions): false | AsarOptions {
+export function createAsarOpts(
+  opts: ProcessedOptionsWithSinglePlatformArch,
+): false | AsarOptions {
   let asarOptions;
   if (opts.asar === true) {
     asarOptions = {};
@@ -73,7 +80,9 @@ export function ensureArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value];
 }
 
-export function isPlatformMac(platform: ComboOptions['platform']) {
+export function isPlatformMac(
+  platform: ProcessedOptionsWithSinglePlatformArch['platform'],
+) {
   return platform === 'darwin' || platform === 'mas';
 }
 

--- a/src/copy-filter.ts
+++ b/src/copy-filter.ts
@@ -9,7 +9,12 @@ import { isJunk } from 'junk';
 import path from 'node:path';
 import { isModule, Pruner } from './prune.js';
 import { officialPlatformArchCombos } from './targets.js';
-import { ComboOptions, Options } from './types.js';
+import {
+  ComboOptions,
+  OfficialArch,
+  OfficialPlatform,
+  Options,
+} from './types.js';
 import { CopyOptions } from 'node:fs';
 
 const DEFAULT_IGNORES = [
@@ -50,9 +55,9 @@ export function generateIgnoredOutDirs(opts: ComboOptions): string[] {
     )) {
       for (const arch of archs) {
         const basenameOpts = {
-          arch: arch,
+          arch: arch as OfficialArch,
           name: opts.name,
-          platform: platform,
+          platform: platform as OfficialPlatform,
         };
         ignoredOutDirs.push(
           path.join(process.cwd(), generateFinalBasename(basenameOpts)),

--- a/src/download.ts
+++ b/src/download.ts
@@ -66,6 +66,7 @@ export async function downloadElectronZip(downloadOpts: DownloadOptions) {
     downloadOpts.arch === 'armv7l' &&
     semver.lt(downloadOpts.version, '1.0.0')
   ) {
+    //@ts-expect-error: this used to be a valid arch for Electron 0.x
     downloadOpts.arch = 'arm';
   }
   debug(`Downloading Electron with options ${JSON.stringify(downloadOpts)}`);

--- a/src/download.ts
+++ b/src/download.ts
@@ -8,15 +8,15 @@ import { createPlatformArchPairs } from './targets.js';
 import {
   DownloadOptions,
   IgnoreFunc,
+  OfficialArch,
+  OfficialPlatform,
   Options,
-  SupportedArch,
-  SupportedPlatform,
 } from './types.js';
 
 export function createDownloadOpts(
   opts: Options,
-  platform: SupportedPlatform,
-  arch: SupportedArch,
+  platform: OfficialPlatform,
+  arch: OfficialArch,
 ): DownloadOptions {
   const downloadOpts = { ...opts.download };
 
@@ -42,8 +42,8 @@ export function createDownloadOpts(
 
 export function createDownloadCombos(
   opts: Options,
-  selectedPlatforms: SupportedPlatform[],
-  selectedArchs: SupportedArch[],
+  selectedPlatforms: OfficialPlatform[],
+  selectedArchs: OfficialArch[],
   ignoreFunc?: IgnoreFunc,
 ) {
   const platformArchPairs = createPlatformArchPairs(

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -7,7 +7,7 @@ import parseAuthor from 'parse-author';
 import path from 'node:path';
 import resolve, { AsyncOpts } from 'resolve';
 import { debug } from './common.js';
-import { Options, SupportedPlatform } from './types.js';
+import { OfficialPlatform, Options } from './types.js';
 
 function isMissingRequiredProperty(props: string[]) {
   return props.some(
@@ -136,7 +136,7 @@ function handleMissingProperties(opts: Options, err: GetPackageInfoError) {
 }
 
 export async function getMetadataFromPackageJSON(
-  platforms: SupportedPlatform[],
+  platforms: OfficialPlatform[],
   opts: Options,
   dir: string,
 ): Promise<void> {

--- a/src/mac.ts
+++ b/src/mac.ts
@@ -511,10 +511,7 @@ export class MacApp extends App implements Plists {
     const platform = this.opts.platform;
     const version = this.opts.electronVersion;
 
-    if (
-      (platform === 'all' || platform === 'mas') &&
-      osxSignOpt === undefined
-    ) {
+    if (platform === 'mas' && osxSignOpt === undefined) {
       warning(
         'signing is required for mas builds. Provide the osx-sign option, ' +
           'or manually sign the app later.',

--- a/src/mac.ts
+++ b/src/mac.ts
@@ -6,11 +6,10 @@ import path from 'node:path';
 import plist, { PlistValue } from 'plist';
 import { notarize, NotarizeOptions } from '@electron/notarize';
 import { ElectronMacPlatform, sign, SignOptions } from '@electron/osx-sign';
-import { ComboOptions } from './types.js';
+import { ProcessedOptionsWithSinglePlatformArch } from './types.js';
 import { generateAssetCatalogForIcon } from './icon-composer.js';
 
 type NSUsageDescription = {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   [key in `NS${string}UsageDescription`]: string;
 };
 
@@ -60,7 +59,10 @@ export class MacApp extends App implements Plists {
   helperRendererPlist: Plists['helperRendererPlist'];
   loginHelperPlist: Plists['loginHelperPlist'];
 
-  constructor(opts: ComboOptions, templatePath: string) {
+  constructor(
+    opts: ProcessedOptionsWithSinglePlatformArch,
+    templatePath: string,
+  ) {
     super(opts, templatePath);
 
     this.appName = opts.name as string;
@@ -203,7 +205,9 @@ export class MacApp extends App implements Plists {
 
   async extendPlist(
     basePlist: BasePList,
-    propsOrFilename: ComboOptions['extendInfo' | 'extendHelperInfo'],
+    propsOrFilename: ProcessedOptionsWithSinglePlatformArch[
+      | 'extendInfo'
+      | 'extendHelperInfo'],
   ) {
     if (!propsOrFilename) {
       return Promise.resolve();
@@ -585,7 +589,7 @@ export { MacApp as App };
  * https://developer.apple.com/library/mac/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102070
  */
 export function filterCFBundleIdentifier(
-  identifier: ComboOptions['appBundleId'],
+  identifier: ProcessedOptionsWithSinglePlatformArch['appBundleId'],
 ) {
   return identifier!.replace(/ /g, '-').replace(/[^a-zA-Z0-9.-]/g, '');
 }
@@ -601,10 +605,13 @@ type CreateSignOptsResult = Mutable<
 >;
 
 export function createSignOpts(
-  properties: Exclude<ComboOptions['osxSign'], undefined>,
-  platform: ComboOptions['platform'],
+  properties: Exclude<
+    ProcessedOptionsWithSinglePlatformArch['osxSign'],
+    undefined
+  >,
+  platform: ProcessedOptionsWithSinglePlatformArch['platform'],
   app: string,
-  version: ComboOptions['electronVersion'],
+  version: ProcessedOptionsWithSinglePlatformArch['electronVersion'],
   quiet?: boolean,
 ): CreateSignOptsResult {
   // use default sign opts if osx-sign is true, otherwise clone osx-sign object
@@ -655,7 +662,7 @@ export function createSignOpts(
 type CreateNotarizeOptsResult = Exclude<NotarizeOptions, { tool?: 'legacy' }>;
 
 export function createNotarizeOpts(
-  properties: ComboOptions['osxNotarize'],
+  properties: ProcessedOptionsWithSinglePlatformArch['osxNotarize'],
   appBundleId: string,
   appPath: string,
   quiet: boolean,

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -23,10 +23,9 @@ import { packageUniversalMac } from './universal.js';
 import {
   ComboOptions,
   DownloadOptions,
+  OfficialArch,
   OfficialPlatform,
   Options,
-  SupportedArch,
-  SupportedPlatform,
 } from './types.js';
 import { App } from './platform.js';
 
@@ -239,8 +238,8 @@ export class Packager {
 
 async function packageAllSpecifiedCombos(
   opts: Options,
-  archs: SupportedArch[],
-  platforms: SupportedPlatform[],
+  archs: OfficialArch[],
+  platforms: OfficialPlatform[],
 ) {
   const packager = new Packager(opts);
   await packager.ensureTempDir();
@@ -277,15 +276,11 @@ async function packageAllSpecifiedCombos(
 export async function packager(opts: Options): Promise<string[]> {
   await debugHostInfo();
 
-  if (debug.enabled) {
-    debug(`Packager Options: ${JSON.stringify(opts)}`);
-  }
+  debug(`Packager Options: ${JSON.stringify(opts)}`);
 
-  const archs = validateListFromOptions(opts, 'arch') as
-    | SupportedArch[]
-    | Error;
+  const archs = validateListFromOptions(opts, 'arch') as OfficialArch[] | Error;
   const platforms = validateListFromOptions(opts, 'platform') as
-    | SupportedPlatform[]
+    | OfficialPlatform[]
     | Error;
 
   if (!Array.isArray(archs)) {
@@ -301,6 +296,7 @@ export async function packager(opts: Options): Promise<string[]> {
 
   const packageJSONDir = path.resolve(process.cwd(), opts.dir) || process.cwd();
 
+  // MUTATION
   await getMetadataFromPackageJSON(platforms, opts, packageJSONDir);
   if (opts.name?.endsWith(' Helper')) {
     throw new Error(
@@ -311,6 +307,7 @@ export async function packager(opts: Options): Promise<string[]> {
   debug(`Application name: ${opts.name}`);
   debug(`Target Electron version: ${opts.electronVersion}`);
 
+  // MUTATION
   populateIgnoredPaths(opts);
 
   await promisifyHooks(opts.afterFinalizePackageTargets, [

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -21,11 +21,12 @@ import {
 import { extractElectronZip } from './unzip.js';
 import { packageUniversalMac } from './universal.js';
 import {
-  ComboOptions,
+  ProcessedOptionsWithSinglePlatformArch,
   DownloadOptions,
   OfficialArch,
   OfficialPlatform,
   Options,
+  ProcessedOptions,
 } from './types.js';
 import { App } from './platform.js';
 
@@ -33,13 +34,53 @@ async function debugHostInfo() {
   debug(await hostInfo());
 }
 
+async function createProcessedOptions(
+  opts: Options,
+  platforms: OfficialPlatform[],
+  packageJSONDir: string,
+): Promise<ProcessedOptions> {
+  const inferredMetadata = await getMetadataFromPackageJSON(
+    platforms,
+    opts,
+    packageJSONDir,
+  );
+  const ignoreProcessing = populateIgnoredPaths(opts);
+
+  const processedOptions = {
+    ...opts,
+    name: opts.name || inferredMetadata.name,
+    appVersion: opts.appVersion || inferredMetadata.appVersion,
+    electronVersion: opts.electronVersion || inferredMetadata.electronVersion,
+    ignore: ignoreProcessing.ignore,
+    originalIgnore: ignoreProcessing.originalIgnore,
+    win32metadata: opts.win32metadata || inferredMetadata.win32metadata,
+  };
+
+  if (isValidProcessedOptions(processedOptions)) {
+    return processedOptions;
+  } else {
+    throw new Error('Invalid processed options');
+  }
+}
+
+function isValidProcessedOptions(
+  opts: Partial<ProcessedOptions>,
+): opts is ProcessedOptions {
+  return (
+    typeof opts.name === 'string' &&
+    typeof opts.appVersion === 'string' &&
+    typeof opts.electronVersion === 'string' &&
+    typeof opts.ignore !== 'undefined'
+  );
+}
+
 export class Packager {
   canCreateSymlinks: boolean | undefined = undefined;
-  opts: Options;
+  opts: ProcessedOptions;
   tempBase: string;
   useTempDir: boolean;
 
-  constructor(opts: Options) {
+  constructor(opts: ProcessedOptions) {
     this.opts = opts;
     this.tempBase = baseTempDir(opts);
     this.useTempDir = opts.tmpdir !== false;
@@ -53,7 +94,10 @@ export class Packager {
     }
   }
 
-  async testSymlink(comboOpts: ComboOptions, zipPath: string) {
+  async testSymlink(
+    comboOpts: ProcessedOptionsWithSinglePlatformArch,
+    zipPath: string,
+  ) {
     await fs.promises.mkdir(this.tempBase, { recursive: true });
     const testPath = await fs.promises.mkdtemp(
       path.join(
@@ -84,7 +128,9 @@ export class Packager {
   }
 
   /* istanbul ignore next */
-  skipHostPlatformSansSymlinkSupport(comboOpts: ComboOptions) {
+  skipHostPlatformSansSymlinkSupport(
+    comboOpts: ProcessedOptionsWithSinglePlatformArch,
+  ) {
     info(
       `Cannot create symlinks (on Windows hosts, it requires admin privileges); skipping ${comboOpts.platform} platform`,
       this.opts.quiet,
@@ -94,7 +140,7 @@ export class Packager {
 
   async overwriteAndCreateApp(
     outDir: string,
-    comboOpts: ComboOptions,
+    comboOpts: ProcessedOptionsWithSinglePlatformArch,
     zipPath: string,
   ) {
     debug(`Removing ${outDir} due to setting overwrite: true`);
@@ -103,7 +149,7 @@ export class Packager {
   }
 
   async extractElectronZip(
-    comboOpts: ComboOptions,
+    comboOpts: ProcessedOptionsWithSinglePlatformArch,
     zipPath: string,
     buildDir: string,
   ) {
@@ -118,8 +164,8 @@ export class Packager {
   }
 
   async buildDir(
-    platform: ComboOptions['platform'],
-    arch: ComboOptions['arch'],
+    platform: ProcessedOptionsWithSinglePlatformArch['platform'],
+    arch: ProcessedOptionsWithSinglePlatformArch['arch'],
   ) {
     let buildParentDir;
     if (this.useTempDir) {
@@ -133,7 +179,10 @@ export class Packager {
     );
   }
 
-  async createApp(comboOpts: ComboOptions, zipPath: string) {
+  async createApp(
+    comboOpts: ProcessedOptionsWithSinglePlatformArch,
+    zipPath: string,
+  ) {
     const buildDir = await this.buildDir(comboOpts.platform, comboOpts.arch);
     info(
       `Packaging app for platform ${comboOpts.platform} ${comboOpts.arch} using electron v${comboOpts.electronVersion}`,
@@ -150,7 +199,10 @@ export class Packager {
     return app.create();
   }
 
-  async checkOverwrite(comboOpts: ComboOptions, zipPath: string) {
+  async checkOverwrite(
+    comboOpts: ProcessedOptionsWithSinglePlatformArch,
+    zipPath: string,
+  ) {
     const finalPath = generateFinalPath(comboOpts);
     if (fs.existsSync(finalPath)) {
       if (this.opts.overwrite) {
@@ -192,7 +244,7 @@ export class Packager {
   }
 
   async packageForPlatformAndArchWithOpts(
-    comboOpts: ComboOptions,
+    comboOpts: ProcessedOptionsWithSinglePlatformArch,
     downloadOpts: DownloadOptions,
   ) {
     const zipPath = await this.getElectronZipPath(downloadOpts);
@@ -215,7 +267,7 @@ export class Packager {
 
   async packageForPlatformAndArch(downloadOpts: DownloadOptions) {
     // Create delegated options object with specific platform and arch, for output directory naming
-    const comboOpts: ComboOptions = {
+    const comboOpts: ProcessedOptionsWithSinglePlatformArch = {
       ...this.opts,
       arch: downloadOpts.arch,
       platform: downloadOpts.platform,
@@ -237,7 +289,7 @@ export class Packager {
 }
 
 async function packageAllSpecifiedCombos(
-  opts: Options,
+  opts: ProcessedOptions,
   archs: OfficialArch[],
   platforms: OfficialPlatform[],
 ) {
@@ -296,27 +348,34 @@ export async function packager(opts: Options): Promise<string[]> {
 
   const packageJSONDir = path.resolve(process.cwd(), opts.dir) || process.cwd();
 
-  // MUTATION
-  await getMetadataFromPackageJSON(platforms, opts, packageJSONDir);
-  if (opts.name?.endsWith(' Helper')) {
+  const processedOpts = await createProcessedOptions(
+    opts,
+    platforms,
+    packageJSONDir,
+  );
+
+  if (processedOpts.name?.endsWith(' Helper')) {
     throw new Error(
       'Application names cannot end in " Helper" due to limitations on macOS',
     );
   }
 
-  debug(`Application name: ${opts.name}`);
-  debug(`Target Electron version: ${opts.electronVersion}`);
+  debug(`Application name: ${processedOpts.name}`);
+  debug(`Target Electron version: ${processedOpts.electronVersion}`);
 
-  // MUTATION
-  populateIgnoredPaths(opts);
-
-  await promisifyHooks(opts.afterFinalizePackageTargets, [
-    createPlatformArchPairs(opts, platforms, archs).map(([platform, arch]) => ({
-      platform,
-      arch,
-    })),
+  await promisifyHooks(processedOpts.afterFinalizePackageTargets, [
+    createPlatformArchPairs(processedOpts, platforms, archs).map(
+      ([platform, arch]) => ({
+        platform,
+        arch,
+      }),
+    ),
   ]);
-  const appPaths = await packageAllSpecifiedCombos(opts, archs, platforms);
+  const appPaths = await packageAllSpecifiedCombos(
+    processedOpts,
+    archs,
+    platforms,
+  );
   // Remove falsy entries (e.g. skipped platforms)
   return appPaths.filter(
     (appPath) => appPath && typeof appPath === 'string',

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -18,7 +18,7 @@ import {
 import { userPathFilter } from './copy-filter.js';
 import { promisifyHooks } from './hooks.js';
 import crypto from 'node:crypto';
-import { ComboOptions } from './types.js';
+import { ProcessedOptionsWithSinglePlatformArch } from './types.js';
 
 export class App {
   asarIntegrity:
@@ -26,10 +26,13 @@ export class App {
     | undefined = undefined;
   asarOptions: ReturnType<typeof createAsarOpts>;
   cachedStagingPath: string | undefined = undefined;
-  opts: ComboOptions;
+  opts: ProcessedOptionsWithSinglePlatformArch;
   templatePath: string;
 
-  constructor(opts: ComboOptions, templatePath: string) {
+  constructor(
+    opts: ProcessedOptionsWithSinglePlatformArch,
+    templatePath: string,
+  ) {
     this.opts = opts;
     this.templatePath = templatePath;
     this.asarOptions = createAsarOpts(opts);
@@ -253,7 +256,10 @@ export class App {
     );
   }
 
-  prebuiltAsarWarning(option: keyof ComboOptions, triggerWarning: unknown) {
+  prebuiltAsarWarning(
+    option: keyof ProcessedOptionsWithSinglePlatformArch,
+    triggerWarning: unknown,
+  ) {
     if (triggerWarning) {
       warning(
         `prebuiltAsar and ${option} are incompatible, ignoring the ${option} option`,
@@ -279,8 +285,8 @@ export class App {
     this.prebuiltAsarWarning(
       'ignore',
       (
-        this.opts as ComboOptions & {
-          originalIgnore: ComboOptions['ignore'];
+        this.opts as ProcessedOptionsWithSinglePlatformArch & {
+          originalIgnore: ProcessedOptionsWithSinglePlatformArch['ignore'];
         }
       ).originalIgnore,
     );

--- a/src/targets.ts
+++ b/src/targets.ts
@@ -180,8 +180,10 @@ export function allOfficialArchsForPlatformAndVersion(
   return archs;
 }
 
-// Validates list of architectures or platforms.
-// Returns a normalized array if successful, or throws an Error.
+/**
+ * Validates list of architectures or platforms.
+ * @returns A normalized array if successful, or throws an Error.
+ */
 export function validateListFromOptions(
   opts: Options,
   name: keyof typeof supported,
@@ -191,12 +193,13 @@ export function validateListFromOptions(
     return Array.from(set.values());
   }
 
-  let list = opts[name];
+  let list: string | string[] | undefined = opts[name];
+
   if (!list) {
     if (name === 'arch') {
       list = getHostArch();
     } else {
-      list = process[name];
+      list = process.platform;
     }
   } else if (list === 'all') {
     return Array.from(set.values());
@@ -210,6 +213,7 @@ export function validateListFromOptions(
     }
   }
 
+  // TODO: how do we properly type non-official electron packages?
   const officialElectronPackages = usingOfficialElectronPackages(opts);
 
   for (const value of list) {

--- a/src/targets.ts
+++ b/src/targets.ts
@@ -17,14 +17,14 @@ export const officialArchs: OfficialArch[] = [
   'arm64',
   'mips64el',
   'universal',
-];
+] as const;
 
 export const officialPlatforms: OfficialPlatform[] = [
   'darwin',
   'linux',
   'mas',
   'win32',
-];
+] as const;
 
 export const officialPlatformArchCombos = {
   darwin: ['x64', 'arm64', 'universal'],

--- a/src/targets.ts
+++ b/src/targets.ts
@@ -67,11 +67,11 @@ export const supported = {
 
 export function createPlatformArchPairs(
   opts: Options,
-  selectedPlatforms: SupportedPlatform[],
-  selectedArchs: SupportedArch[],
+  selectedPlatforms: OfficialPlatform[],
+  selectedArchs: OfficialArch[],
   ignoreFunc?: IgnoreFunc,
 ) {
-  const combinations: Array<[SupportedPlatform, SupportedArch]> = [];
+  const combinations: Array<[OfficialPlatform, OfficialArch]> = [];
 
   for (const arch of selectedArchs) {
     if (arch === 'universal' && process.platform !== 'darwin') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -635,8 +635,8 @@ export interface Options {
  * @internal
  */
 interface OptionsWithRequiredArchAndPlatform extends Options {
-  arch: Exclude<Options['arch'], undefined>;
-  platform: Exclude<Options['platform'], undefined>;
+  arch: Exclude<Options['arch'], undefined | string[]>;
+  platform: Exclude<Options['platform'], undefined | string[]>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,11 +37,6 @@ export type OfficialArch =
  */
 export type OfficialPlatform = 'linux' | 'win32' | 'darwin' | 'mas';
 
-export type TargetArch = OfficialArch | string;
-export type TargetPlatform = OfficialPlatform | string;
-export type ArchOption = TargetArch | 'all';
-export type PlatformOption = TargetPlatform | 'all';
-
 /**
  * Architecture values that we actually support out of the box (not considering unofficial values provided in
  * `download.mirrorOptions`).
@@ -111,15 +106,16 @@ export type HookFunctionErrorCallback = (err?: Error | null) => void;
 export type HookFunction = (
   buildPath: string,
   electronVersion: string,
-  platform: TargetPlatform,
-  arch: TargetArch,
+  platform: OfficialPlatform,
+  arch: OfficialArch,
   callback: HookFunctionErrorCallback,
 ) => void;
 
 export type TargetDefinition = {
-  arch: TargetArch;
-  platform: TargetPlatform;
+  arch: OfficialArch;
+  platform: OfficialPlatform;
 };
+
 export type FinalizePackageTargetsHookFunction = (
   targets: TargetDefinition[],
   callback: HookFunctionErrorCallback,
@@ -294,7 +290,7 @@ export interface Options {
    * - `arm64` _(Linux: Electron 1.8.0 and above; Windows: 6.0.8 and above; macOS: 11.0.0-beta.1 and above)_
    * - `mips64el` _(Electron 1.8.2-beta.5 to 1.8.8)_
    */
-  arch?: ArchOption | ArchOption[];
+  arch?: SupportedArch | SupportedArch[];
   /**
    * Whether to package the application's source code into an archive, using [Electron's
    * archive format](https://github.com/electron/asar). Reasons why you may want to enable
@@ -549,7 +545,7 @@ export interface Options {
    * - `mas` (macOS, specifically for submitting to the Mac App Store)
    * - `win32`
    */
-  platform?: TargetPlatform | 'all' | Array<TargetPlatform | 'all'>;
+  platform?: OfficialPlatform | 'all' | Array<OfficialPlatform | 'all'>;
   /**
    * The path to a prebuilt ASAR file.
    *
@@ -635,8 +631,8 @@ export interface Options {
  * @internal
  */
 interface OptionsWithRequiredArchAndPlatform extends Options {
-  arch: Exclude<Options['arch'], undefined | string[]>;
-  platform: Exclude<Options['platform'], undefined | string[]>;
+  arch: Exclude<Options['arch'], undefined | string[] | 'all'>;
+  platform: Exclude<Options['platform'], undefined | string[] | 'all'>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -628,25 +628,33 @@ export interface Options {
 }
 
 /**
+ * Processed options with populated defaults and inferred values, used internally by the Packager class.
+ * This represents the cleaned and processed version of the input Options.
  * @internal
  */
-interface OptionsWithRequiredArchAndPlatform extends Options {
-  arch: Exclude<Options['arch'], undefined | string[] | 'all'>;
-  platform: Exclude<Options['platform'], undefined | string[] | 'all'>;
+export interface ProcessedOptions extends Options {
+  name: string;
+  appVersion: string;
+  electronVersion: string;
+  ignore: Array<string | RegExp> | IgnoreFunction;
+  originalIgnore?: Options['ignore'];
+  win32metadata?: Win32MetadataOptions;
 }
 
 /**
  * @internal
  */
-export interface DownloadOptions extends OptionsWithRequiredArchAndPlatform {
+export interface ProcessedOptionsWithSinglePlatformArch
+  extends ProcessedOptions {
+  arch: OfficialArch;
+  platform: OfficialPlatform;
+}
+
+/**
+ * @internal
+ */
+export interface DownloadOptions
+  extends ProcessedOptionsWithSinglePlatformArch {
   artifactName: string;
   version: string;
-}
-
-/**
- * @internal
- */
-export interface ComboOptions extends Options {
-  arch: OptionsWithRequiredArchAndPlatform['arch'];
-  platform: OptionsWithRequiredArchAndPlatform['platform'];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -638,7 +638,6 @@ export interface ProcessedOptions extends Options {
   electronVersion: string;
   ignore: Array<string | RegExp> | IgnoreFunction;
   originalIgnore?: Options['ignore'];
-  win32metadata?: Win32MetadataOptions;
 }
 
 /**

--- a/src/universal.ts
+++ b/src/universal.ts
@@ -4,7 +4,7 @@ import fs from 'graceful-fs';
 import { promisifiedGracefulFs } from './util.js';
 import path from 'node:path';
 import { App } from './mac.js';
-import { ComboOptions, DownloadOptions, SupportedArch } from './types.js';
+import { ComboOptions, DownloadOptions, OfficialArch } from './types.js';
 import { Packager } from './packager.js';
 
 export async function packageUniversalMac(
@@ -44,10 +44,10 @@ export async function packageUniversalMac(
     }
   }
 
-  const tempPackages = {} as Record<SupportedArch, string>;
+  const tempPackages = {} as Record<OfficialArch, string>;
 
   await Promise.all(
-    (['x64', 'arm64'] as SupportedArch[]).map(async (tempArch) => {
+    (['x64', 'arm64'] as OfficialArch[]).map(async (tempArch) => {
       const tempOpts = {
         ...comboOpts,
         arch: tempArch,

--- a/src/universal.ts
+++ b/src/universal.ts
@@ -4,13 +4,17 @@ import fs from 'graceful-fs';
 import { promisifiedGracefulFs } from './util.js';
 import path from 'node:path';
 import { App } from './mac.js';
-import { ComboOptions, DownloadOptions, OfficialArch } from './types.js';
+import {
+  ProcessedOptionsWithSinglePlatformArch,
+  DownloadOptions,
+  OfficialArch,
+} from './types.js';
 import { Packager } from './packager.js';
 
 export async function packageUniversalMac(
   packageForPlatformAndArchWithOpts: Packager['packageForPlatformAndArchWithOpts'],
   buildDir: string,
-  comboOpts: ComboOptions,
+  comboOpts: ProcessedOptionsWithSinglePlatformArch,
   downloadOpts: DownloadOptions,
   tempBase: string,
 ) {

--- a/src/win32.ts
+++ b/src/win32.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { sign, SignOptionsForDirectory } from '@electron/windows-sign';
 import { App } from './platform.js';
 import { debug, sanitizeAppName, warning } from './common.js';
-import { ComboOptions, Options } from './types.js';
+import { ProcessedOptionsWithSinglePlatformArch, Options } from './types.js';
 import { ExeMetadata, resedit } from './resedit.js';
 
 export class WindowsApp extends App {
@@ -122,8 +122,11 @@ type CreateSignOptsResult = SignOptionsForDirectory & {
 };
 
 function createSignOpts(
-  properties: Exclude<ComboOptions['windowsSign'], undefined>,
-  windowsMetaData: ComboOptions['win32metadata'],
+  properties: Exclude<
+    ProcessedOptionsWithSinglePlatformArch['windowsSign'],
+    undefined
+  >,
+  windowsMetaData: ProcessedOptionsWithSinglePlatformArch['win32metadata'],
   appDirectory: string,
 ): CreateSignOptsResult {
   if (typeof properties === 'object') {

--- a/test/common.spec.ts
+++ b/test/common.spec.ts
@@ -9,7 +9,10 @@ import {
 import { createDownloadOpts } from '../src/download.js';
 
 import { describe, it, expect, vi } from 'vitest';
-import { ComboOptions, Options } from '../src/types.js';
+import {
+  ProcessedOptionsWithSinglePlatformArch,
+  Options,
+} from '../src/types.js';
 import path from 'node:path';
 
 describe('logger', () => {
@@ -128,25 +131,37 @@ describe('validateElectronApp', () => {
 
 describe('createAsarOpts', () => {
   it('returns false if asar is not set', () => {
-    expect(createAsarOpts({} as ComboOptions)).toBe(false);
+    expect(createAsarOpts({} as ProcessedOptionsWithSinglePlatformArch)).toBe(
+      false,
+    );
   });
   it('returns false if asar is false', () => {
-    expect(createAsarOpts({ asar: false } as ComboOptions)).toBe(false);
+    expect(
+      createAsarOpts({ asar: false } as ProcessedOptionsWithSinglePlatformArch),
+    ).toBe(false);
   });
 
   it('sets asar options to {} if true', () => {
-    expect(createAsarOpts({ asar: true } as ComboOptions)).toEqual({});
+    expect(
+      createAsarOpts({ asar: true } as ProcessedOptionsWithSinglePlatformArch),
+    ).toEqual({});
   });
 
   it('sets asar options to the value if it is an object', () => {
-    expect(createAsarOpts({ asar: { dot: true } } as ComboOptions)).toEqual({
+    expect(
+      createAsarOpts({
+        asar: { dot: true },
+      } as ProcessedOptionsWithSinglePlatformArch),
+    ).toEqual({
       dot: true,
     });
   });
 
   it('returns false if asar is not an object or a boolean', () => {
-    expect(createAsarOpts({ asar: 'test' } as unknown as ComboOptions)).toBe(
-      false,
-    );
+    expect(
+      createAsarOpts({
+        asar: 'test',
+      } as unknown as ProcessedOptionsWithSinglePlatformArch),
+    ).toBe(false);
   });
 });

--- a/test/copy-filter.spec.ts
+++ b/test/copy-filter.spec.ts
@@ -7,7 +7,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { ComboOptions, Options } from '../src/types.js';
+import {
+  ProcessedOptionsWithSinglePlatformArch,
+  Options,
+} from '../src/types.js';
 
 describe('populateIgnoredPaths', () => {
   let tempDir: string;
@@ -22,12 +25,12 @@ describe('populateIgnoredPaths', () => {
     const expected = path.join(tmpdir, 'electron-packager');
     const opts = { tmpdir } as Options;
 
-    populateIgnoredPaths(opts);
+    const result = populateIgnoredPaths(opts);
 
     if (process.platform === 'linux') {
-      expect(opts.ignore).toContain(expected);
+      expect(result.ignore).toContain(expected);
     } else {
-      expect(opts.ignore).not.toContain(expected);
+      expect(result.ignore).not.toContain(expected);
     }
   });
 
@@ -37,11 +40,15 @@ describe('populateIgnoredPaths', () => {
       dir: path.join(__dirname, 'fixtures', 'basic'),
     } as Options;
 
-    populateIgnoredPaths(opts);
+    const ignoreResult = populateIgnoredPaths(opts);
+    const processedOpts = {
+      ...opts,
+      ...ignoreResult,
+    } as ProcessedOptionsWithSinglePlatformArch;
     const targetDir = path.join(tempDir, 'result');
     await fs.promises.cp(opts.dir, targetDir, {
       dereference: false,
-      filter: userPathFilter(opts as ComboOptions),
+      filter: userPathFilter(processedOpts),
       recursive: true,
     });
 
@@ -83,7 +90,7 @@ describe('userPathFilter', () => {
     const targetDir = path.join(tempDir, 'result');
     await fs.promises.cp(opts.dir, targetDir, {
       dereference: false,
-      filter: userPathFilter(opts as ComboOptions),
+      filter: userPathFilter(opts as ProcessedOptionsWithSinglePlatformArch),
       recursive: true,
     });
 
@@ -104,7 +111,7 @@ describe('userPathFilter', () => {
     const targetDir = path.join(tempDir, 'result');
     await fs.promises.cp(opts.dir, targetDir, {
       dereference: false,
-      filter: userPathFilter(opts as ComboOptions),
+      filter: userPathFilter(opts as ProcessedOptionsWithSinglePlatformArch),
       recursive: true,
     });
 
@@ -127,7 +134,7 @@ describe('userPathFilter', () => {
     const targetDir = path.join(tempDir, 'result');
     await fs.promises.cp(opts.dir, targetDir, {
       dereference: false,
-      filter: userPathFilter(opts as ComboOptions),
+      filter: userPathFilter(opts as ProcessedOptionsWithSinglePlatformArch),
       recursive: true,
     });
 
@@ -149,7 +156,7 @@ describe('userPathFilter', () => {
     const targetDir = path.join(tempDir, 'result');
     await fs.promises.cp(opts.dir, targetDir, {
       dereference: false,
-      filter: userPathFilter(opts as ComboOptions),
+      filter: userPathFilter(opts as ProcessedOptionsWithSinglePlatformArch),
       recursive: true,
     });
 
@@ -161,7 +168,9 @@ describe('userPathFilter', () => {
 
 describe('generateIgnoredOutDirs', () => {
   it('ignores all possible platform/arch permutations', () => {
-    const ignores = generateIgnoredOutDirs({ name: 'test' } as ComboOptions);
+    const ignores = generateIgnoredOutDirs({
+      name: 'test',
+    } as ProcessedOptionsWithSinglePlatformArch);
     const relativeIgnores = ignores.map((ignore) =>
       path.relative(process.cwd(), ignore),
     );

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -40,7 +40,7 @@ describe('promisifyHooks', () => {
       );
 
       const runSerialHook = serialHooks(testHooks);
-      await runSerialHook('', '', '', '', () => {});
+      await runSerialHook('', '', 'darwin', 'arm64', () => {});
       expect(output).toBe('0 1 2 3 4 5 6 7 8 9 10');
     });
   });

--- a/test/infer.spec.ts
+++ b/test/infer.spec.ts
@@ -17,11 +17,11 @@ describe('getMetadataFromPackageJSON', () => {
       dir,
     };
     const packageJSON = await import(path.join(dir, 'package.json'));
-    await getMetadataFromPackageJSON([], opts, opts.dir);
-    expect(opts.electronVersion).toBeDefined();
+    const result = await getMetadataFromPackageJSON([], opts, opts.dir);
+    expect(result.electronVersion).toBeDefined();
     expect(
       semver.satisfies(
-        opts.electronVersion!,
+        result.electronVersion!,
         packageJSON.devDependencies[packageName],
       ),
     ).toBe(true);
@@ -50,8 +50,12 @@ describe('getMetadataFromPackageJSON', () => {
         electronVersion: config.version,
         dir: tempDir,
       };
-      await getMetadataFromPackageJSON(['win32'], opts, opts.dir);
-      expect(opts.win32metadata).toEqual({ CompanyName: 'Foo Bar' });
+      const result = await getMetadataFromPackageJSON(
+        ['win32'],
+        opts,
+        opts.dir,
+      );
+      expect(result.win32metadata).toEqual({ CompanyName: 'Foo Bar' });
     });
 
     it('does not infer win32metadata if it already exists', async () => {
@@ -62,7 +66,12 @@ describe('getMetadataFromPackageJSON', () => {
           CompanyName: 'Existing',
         },
       };
-      await getMetadataFromPackageJSON(['win32'], opts, opts.dir);
+      const result = await getMetadataFromPackageJSON(
+        ['win32'],
+        opts,
+        opts.dir,
+      );
+      expect(result.win32metadata).toBeUndefined();
       expect(opts.win32metadata).toEqual({ CompanyName: 'Existing' });
     });
 
@@ -86,8 +95,12 @@ describe('getMetadataFromPackageJSON', () => {
         electronVersion: config.version,
       };
 
-      await getMetadataFromPackageJSON(['win32'], opts, opts.dir);
-      expect(opts.win32metadata).toEqual({ CompanyName: 'Jane Doe' });
+      const result = await getMetadataFromPackageJSON(
+        ['win32'],
+        opts,
+        opts.dir,
+      );
+      expect(result.win32metadata).toEqual({ CompanyName: 'Jane Doe' });
     });
 
     it('does not infer win32metadata when author is an object without a name', async () => {
@@ -109,8 +122,12 @@ describe('getMetadataFromPackageJSON', () => {
         electronVersion: config.version,
       };
 
-      await getMetadataFromPackageJSON(['win32'], opts, opts.dir);
-      expect(opts.win32metadata).toEqual({});
+      const result = await getMetadataFromPackageJSON(
+        ['win32'],
+        opts,
+        opts.dir,
+      );
+      expect(result.win32metadata).toEqual({});
     });
 
     it('throws if no author is provided', async () => {

--- a/test/resedit.spec.ts
+++ b/test/resedit.spec.ts
@@ -4,7 +4,15 @@ import { describe, it, expect } from 'vitest';
 
 describe('resedit', () => {
   it('sets win32Metadata defaults', async () => {
-    const opts = { name: 'Win32 App', arch: 'x64', platform: 'win32', dir: '' };
+    const opts = {
+      name: 'Win32 App',
+      arch: 'x64',
+      platform: 'win32',
+      dir: '',
+      appVersion: '1.0.0',
+      electronVersion: '1.0.0',
+      ignore: () => false,
+    } as const;
     const app = new WindowsApp(opts, '');
     const rcOpts = app.generateReseditOptionsSansIcon();
 
@@ -71,8 +79,11 @@ describe('resedit', () => {
         arch: 'x64',
         platform: 'win32',
         dir: '',
+        electronVersion: '1.0.0',
+        ignore: () => false,
+        appVersion: '1.0.0',
         ...testOpts,
-      };
+      } as const;
       const app = new WindowsApp(opts, '');
       const rcOpts = app.generateReseditOptionsSansIcon();
 

--- a/test/targets.spec.ts
+++ b/test/targets.spec.ts
@@ -7,7 +7,7 @@ import {
 
 import path from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
-import { Options, SupportedPlatform, SupportedArch } from '../src/types.js';
+import { Options, OfficialPlatform, OfficialArch } from '../src/types.js';
 import config from './config.json' with { type: 'json' };
 
 describe('allOfficialArchsForPlatformAndVersion', () => {
@@ -159,18 +159,18 @@ describe('createPlatformArchPairs', () => {
       expectedLength: 1,
     },
   ])('builds for $testCase', ({ extraOpts, expectedLength }) => {
-    const opts: Options = {
+    const opts = {
       name: 'test',
       dir: path.join(__dirname, 'fixtures', 'basic'),
       electronVersion: config.version,
       ...extraOpts,
-    };
+    } as Options;
 
     const platforms = validateListFromOptions(
       opts,
       'platform',
-    ) as SupportedPlatform[];
-    const archs = validateListFromOptions(opts, 'arch') as SupportedArch[];
+    ) as OfficialPlatform[];
+    const archs = validateListFromOptions(opts, 'arch') as OfficialArch[];
     const result = createPlatformArchPairs(opts, platforms, archs);
 
     expect(result.length).toEqual(expectedLength);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,12 +3,15 @@ import path from 'node:path';
 import os from 'node:os';
 import plist, { PlistObject } from 'plist';
 import { it as originalIt } from 'vitest';
-import type { ComboOptions, Options } from '../src/types.js';
+import type {
+  ProcessedOptionsWithSinglePlatformArch,
+  Options,
+} from '../src/types.js';
 import { isPlatformMac, sanitizeAppName } from '../src/common.js';
 import config from './config.json' with { type: 'json' };
 
 export function generateResourcesPath(
-  opts: Pick<ComboOptions, 'name' | 'platform'>,
+  opts: Pick<ProcessedOptionsWithSinglePlatformArch, 'name' | 'platform'>,
 ) {
   if (isPlatformMac(opts.platform)) {
     return path.join(`${opts.name}.app`, 'Contents', 'Resources');
@@ -17,7 +20,7 @@ export function generateResourcesPath(
 }
 
 export function generateNamePath(
-  opts: Pick<ComboOptions, 'name' | 'platform'>,
+  opts: Pick<ProcessedOptionsWithSinglePlatformArch, 'name' | 'platform'>,
 ) {
   if (isPlatformMac(opts.platform)) {
     return path.join(
@@ -66,7 +69,10 @@ export function parseHelperInfoPlist(
 }
 
 interface ItContext {
-  baseOpts: Options;
+  baseOpts: Options &
+    Required<
+      Pick<Options, 'name' | 'dir' | 'electronVersion' | 'out' | 'tmpdir'>
+    >;
 }
 
 /**
@@ -82,7 +88,7 @@ export const it = originalIt.extend<ItContext>({
       path.join(os.tmpdir(), 'electron-packager-test-tmpdir-'),
     );
 
-    const opts: Options = {
+    const opts = {
       name: 'packagerTest',
       dir: path.join(__dirname, 'fixtures', 'basic'),
       electronVersion: config.version,


### PR DESCRIPTION
This PR attempts to simplify how we handle the `Options` interface in Electron Packager.

There are two main problems to address:

1. External: the `TargetArch` and `TargetPlatform` types used in the `Options` interface are aliases to `string`. This is because we accept `string` values for custom mirrors of Electron, so any string const value passed in gets swallowed by the resulting type.

  ```ts
  // the following types are functionally equivalent in TS!
  type TargetArch1 = 'arch1' | 'arch2' | string;
  type TargetArch2 = string;
  ```
2. Internal: the `Options` interface defines what options can be passed in as values, but also serves as the interface that we use to pass to the final packaging function. Along the way, many optional properties in `Options` are inferred and mutated. This approach makes our types inaccurate internally because we're using `Options` everywhere, even after inference occurs and some optional properties become required.

At a high level, we're addressing the two problems with some type refactors.

1. We no longer support arbitrary `string` values as `platform` and `arch` inputs in the types. This removes the superfluous `ArchOption`, `PlatformOption`, `TargetArch`, and `TargetPlatform` types. Users passing custom arch/platform values can still do so, but must cast their parameters using the `OfficalArch` and `OfficialPlatform` types.
2. `Options` now explicitly refers to the options that are passed in by the user. `ProcessedOptions` refers to the Options object after it is processed/inferred via metadata. `ProcessedOptionsWithSinglePlatformArch` refers to the ProcessedOptions object once it is guaranteed to have a single platform or arch value (rather than an array or comma-separated string). We use a fresh opts object every time the shape of our options changes rather than mutating the initial Options being passed in.

> [!NOTE]
> There are some additional refactors we can make for future work to make this delineation clearer.
> For example, the `Packager` class takes in `ProcessedOptions` as a parameter, which means `opts.arch` and `opts.platform` can be an array. However, these values are never used—`Packager` instance functions are only ever called with a separate `ProcessedOptionsWithSinglePlatformArch` arg.


