### PR TITLE
ci: make CI run on any PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   pull_request:
-    branches:
-      - main
   schedule:
     - cron: '0 22 * * 3'
   workflow_call:


### PR DESCRIPTION
Removed `main` branch restriction for pull request trigger

Helps when stacking PRs on top of each other. :)

