### PR TITLE
ci: fix setup-node in canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # tag: v5.0.0
         with:
-          node-version-file: .nvmrc
+          # electron/minimal-repro doesn't have a .nvmrc file
+          node-version: lts/*
       - name: Replace electron with electron-nightly
         run: |
           cd minimal-repro


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

We accidentally broke the canary workflow in #1821 because we only check out `electron/minimal-repro` there, and that repo doesn't have a `.nvmrc` file.

It probably also makes sense for the canary workflow to be using the latest Node.js anyway to catch any potential errors.